### PR TITLE
Add Nix flake devshell with direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ log/
 .DS_Store
 .cache
 project/project/
+.envrc
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "Dev environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forEachSystem = f: builtins.listToAttrs (map (system: {
+        name = system;
+        value = f system;
+      }) supportedSystems);
+    in {
+      devShells = forEachSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [ jdk21 sbt ];
+            shellHook = ''
+              export JAVA_HOME="${pkgs.jdk21}"
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Add flake.nix + .envrc for local dev with direnv/nix-direnv. Dual-arch (x86_64 + aarch64).

Closes #5